### PR TITLE
Make DynamicOscillators waveformUpdateHandler public

### DIFF
--- a/Sources/CSoundpipeAudioKit/Generators/DynamicOscillatorDSP.mm
+++ b/Sources/CSoundpipeAudioKit/Generators/DynamicOscillatorDSP.mm
@@ -108,10 +108,7 @@ public:
     }
 
     void updateTables() {
-
         // Check for new waveforms.
-        int32_t bytes;
-
         auto next = nextWavetable.load();
         if(next != newTable) {
             if(oldTable) { oldTable->done = true; }

--- a/Sources/SoundpipeAudioKit/Generators/DynamicOscillator.swift
+++ b/Sources/SoundpipeAudioKit/Generators/DynamicOscillator.swift
@@ -19,8 +19,8 @@ public class DynamicOscillator: DynamicWaveformNode {
 
     fileprivate var waveform: Table?
 
-    /// Callback whten the wavetable is updated
-    var waveformUpdateHandler: ([Float]) -> Void = { _ in }
+    /// Callback when the wavetable is updated
+    public var waveformUpdateHandler: ([Float]) -> Void = { _ in }
 
     /// Specification details for frequency
     public static let frequencyDef = NodeParameterDef(


### PR DESCRIPTION
- made waveformUpdateHandler public
- fixed a typo
- removed an unused variable "bytes" from the DSP file

PS: the new process method in DynamicOscillatorDSP looks really clean!

Also, I was signed into the wrong account when I made the commit, so ignore the 2 participants. They are both me.