### PR TITLE
Add crashing test case when using dry wet in mixer

### DIFF
--- a/Tests/SoundpipeAudioKitTests/DryWetMixerTests.swift
+++ b/Tests/SoundpipeAudioKitTests/DryWetMixerTests.swift
@@ -55,6 +55,16 @@ class DryWetMixerTests: XCTestCase {
         audio.append(engine.render(duration: 1.0))
         testMD5(audio)
     }
+
+    func testDryWetInMixerDoesntCrash() {
+        let engine = AudioEngine()
+        let input = Oscillator()
+        let bitcrusher = BitCrusher(input)
+        let dryWet = DryWetMixer(BitCrusher(bitcrusher), bitcrusher)
+
+        let mix = Mixer(input, dryWet)
+        engine.output = mix
+    }
     
     /* Test produces different results on local machine vs CI
     func testDetachWhileHavingAnInputMixer() {


### PR DESCRIPTION
Possibly related to https://github.com/AudioKit/AudioKit/issues/2377

Few things I noticed:
- Using Mixer instead of DryWetMixer doesn't crash
- Using only one BitCrusher (or any effect) in chain doesn't crash
- Adding mixer inputs after `engine.output` assignment still crashes
