### PR TITLE
Close IR file reference

### DIFF
--- a/Sources/SoundpipeAudioKit/Effects/Convolution.swift
+++ b/Sources/SoundpipeAudioKit/Effects/Convolution.swift
@@ -127,6 +127,7 @@ public class Convolution: Node {
                         bufferList.mBuffers.mData?.assumingMemoryBound(to: Float.self)
                     )
                     au.setWavetable(data: data, size: Int(ioNumberFrames))
+                    ExtAudioFileDispose(externalAudioFileRef)
                 } else {
                     // failure
                     theData?.deallocate()


### PR DESCRIPTION
The Convolution effect Node creates an external file reference to load the impulse response, but the reference was never closed. Just now calling ExtAudioFileDispose, once the wavetable has been loaded.