### PR TITLE
Added makeup gain and dry wet mix to DynamicRangeCompressor

### DIFF
--- a/Sources/SoundpipeAudioKit/Effects/DynamicRangeCompressor.swift
+++ b/Sources/SoundpipeAudioKit/Effects/DynamicRangeCompressor.swift
@@ -69,6 +69,32 @@ public class DynamicRangeCompressor: Node {
 
     /// Release Duration
     @Parameter(releaseDurationDef) public var releaseDuration: AUValue
+    
+    /// Specification details for gain
+    public static let gainDef = NodeParameterDef(
+        identifier: "gain",
+        name: "Makeup Gain",
+        address: akGetParameterAddress("DynamicRangeCompressorParameterGain"),
+        defaultValue: 1.0,
+        range: 0.0 ... 8.0,
+        unit: .linearGain
+    )
+
+    /// Makeup gain applied only to processed signal
+    @Parameter(gainDef) public var gain: AUValue
+
+    /// Specification details for dryWetMix
+    public static let dryWetMixDef = NodeParameterDef(
+        identifier: "dryWetMix",
+        name: "Dry/Wet Mix",
+        address: akGetParameterAddress("DynamicRangeCompressorParameterDryWetMix"),
+        defaultValue: 1.0,
+        range: 0.0 ... 1.0,
+        unit: .percent
+    )
+
+    /// Dry/Wet Mix
+    @Parameter(dryWetMixDef) public var dryWetMix: AUValue
 
     // MARK: - Initialization
 
@@ -80,13 +106,17 @@ public class DynamicRangeCompressor: Node {
     ///   - threshold: Threshold (in dB) 0 = max
     ///   - attackDuration: Attack duration
     ///   - releaseDuration: Release Duration
+    ///   - gain: Makeup gain (applied only to processing)
+    ///   - dryWetMix: Dry/Wet Mix
     ///
     public init(
         _ input: Node,
         ratio: AUValue = ratioDef.defaultValue,
         threshold: AUValue = thresholdDef.defaultValue,
         attackDuration: AUValue = attackDurationDef.defaultValue,
-        releaseDuration: AUValue = releaseDurationDef.defaultValue
+        releaseDuration: AUValue = releaseDurationDef.defaultValue,
+        gain: AUValue = gainDef.defaultValue,
+        dryWetMix: AUValue = dryWetMixDef.defaultValue
     ) {
         self.input = input
 
@@ -96,5 +126,7 @@ public class DynamicRangeCompressor: Node {
         self.threshold = threshold
         self.attackDuration = attackDuration
         self.releaseDuration = releaseDuration
+        self.gain = gain
+        self.dryWetMix = dryWetMix
     }
 }

--- a/Sources/SoundpipeAudioKit/Effects/DynamicRangeCompressor.swift
+++ b/Sources/SoundpipeAudioKit/Effects/DynamicRangeCompressor.swift
@@ -69,7 +69,7 @@ public class DynamicRangeCompressor: Node {
 
     /// Release Duration
     @Parameter(releaseDurationDef) public var releaseDuration: AUValue
-    
+
     /// Specification details for gain
     public static let gainDef = NodeParameterDef(
         identifier: "gain",


### PR DESCRIPTION
This introduces dedicated gain and dry/wet mix controls for the DynamicRangeCompressor:
- Gain Control: The current compressor only reduces the signal level. In audio applications, it's common to apply makeup gain to compensate for this reduction, bringing the overall signal level back up.
- Dry/Wet Mix Control: This allows for convenient parallel compression, blending the processed (compressed) signal with the unprocessed (dry) signal.

Processing Logic:
- Makeup Gain: Applied only to the processed (compressed) signal.
- Dry/Wet Mix: Computed after the makeup gain is applied.