### PR TITLE
Added dry wet to distortion

### DIFF
--- a/Sources/CSoundpipeAudioKit/Effects/TanhDistortionDSP.mm
+++ b/Sources/CSoundpipeAudioKit/Effects/TanhDistortionDSP.mm
@@ -9,6 +9,7 @@ enum TanhDistortionParameter : AUParameterAddress {
     TanhDistortionParameterPostgain,
     TanhDistortionParameterPositiveShapeParameter,
     TanhDistortionParameterNegativeShapeParameter,
+    TanhDistortionParameterDryWetMix,
 };
 
 class TanhDistortionDSP : public SoundpipeDSPBase {
@@ -19,6 +20,7 @@ private:
     ParameterRamper postgainRamp;
     ParameterRamper positiveShapeParameterRamp;
     ParameterRamper negativeShapeParameterRamp;
+    ParameterRamper dryWetMixRamp;
 
 public:
     TanhDistortionDSP() {
@@ -26,6 +28,7 @@ public:
         parameters[TanhDistortionParameterPostgain] = &postgainRamp;
         parameters[TanhDistortionParameterPositiveShapeParameter] = &positiveShapeParameterRamp;
         parameters[TanhDistortionParameterNegativeShapeParameter] = &negativeShapeParameterRamp;
+        parameters[TanhDistortionParameterDryWetMix] = &dryWetMixRamp;
     }
 
     void init(int channelCount, double sampleRate) override {
@@ -65,6 +68,10 @@ public:
 
             sp_dist_compute(sp, dist0, &leftIn, &leftOut);
             sp_dist_compute(sp, dist1, &rightIn, &rightOut);
+            
+            float dryWetMix = dryWetMixRamp.getAndStep();
+            outputSample(0, i) = dryWetMix * leftOut + (1.0f - dryWetMix) * leftIn;
+            outputSample(1, i) = dryWetMix * rightOut + (1.0f - dryWetMix) * rightIn;
         }
     }
 };
@@ -74,3 +81,4 @@ AK_REGISTER_PARAMETER(TanhDistortionParameterPregain)
 AK_REGISTER_PARAMETER(TanhDistortionParameterPostgain)
 AK_REGISTER_PARAMETER(TanhDistortionParameterPositiveShapeParameter)
 AK_REGISTER_PARAMETER(TanhDistortionParameterNegativeShapeParameter)
+AK_REGISTER_PARAMETER(TanhDistortionParameterDryWetMix)

--- a/Sources/SoundpipeAudioKit/Effects/TanhDistortion.swift
+++ b/Sources/SoundpipeAudioKit/Effects/TanhDistortion.swift
@@ -70,6 +70,19 @@ public class TanhDistortion: Node {
     /// Like the positive shape parameter, only for the negative part.
     @Parameter(negativeShapeParameterDef) public var negativeShapeParameter: AUValue
 
+    /// Specification details for dryWetMix
+    public static let dryWetMixDef = NodeParameterDef(
+        identifier: "dryWetMix",
+        name: "Dry/Wet Mix",
+        address: akGetParameterAddress("TanhDistortionParameterDryWetMix"),
+        defaultValue: 1.0,
+        range: 0.0 ... 1.0,
+        unit: .percent
+    )
+
+    /// Dry/Wet Mix
+    @Parameter(dryWetMixDef) public var dryWetMix: AUValue
+
     // MARK: - Initialization
 
     /// Initialize this distortion node
@@ -77,16 +90,18 @@ public class TanhDistortion: Node {
     /// - Parameters:
     ///   - input: Input node to process
     ///   - pregain: Determines gain applied to the signal before waveshaping. A value of 1 gives slight distortion.
-    ///   - postgain: Gain applied after waveshaping
+    ///   - postgain: Gain applied after waveshaping (applied only to processed signal)
     ///   - positiveShapeParameter: Shape of the positive part of the signal. A value of 0 gets a flat clip.
     ///   - negativeShapeParameter: Like the positive shape parameter, only for the negative part.
+    ///   - dryWetMix: Dry/Wet Mix
     ///
     public init(
         _ input: Node,
         pregain: AUValue = pregainDef.defaultValue,
         postgain: AUValue = postgainDef.defaultValue,
         positiveShapeParameter: AUValue = positiveShapeParameterDef.defaultValue,
-        negativeShapeParameter: AUValue = negativeShapeParameterDef.defaultValue
+        negativeShapeParameter: AUValue = negativeShapeParameterDef.defaultValue,
+        dryWetMix: AUValue = dryWetMixDef.defaultValue
     ) {
         self.input = input
 
@@ -96,5 +111,6 @@ public class TanhDistortion: Node {
         self.postgain = postgain
         self.positiveShapeParameter = positiveShapeParameter
         self.negativeShapeParameter = negativeShapeParameter
+        self.dryWetMix = dryWetMix
     }
 }


### PR DESCRIPTION
This introduces dedicated dry/wet mix control for TanhDistortion. This allows for convenient parallel distortion - blending the processed (distorted) signal with the unprocessed (dry) signal.

Processing Logic:

Post Gain: Applied only to the processed (distorted) signal.
Dry/Wet Mix: Computed after the post gain is applied to distorted signal.