### PR TITLE
Fixing a memory leak from not deallocating audio data pointer

### DIFF
--- a/Sources/SoundpipeAudioKit/Generators/PhaseLockedVocoder.swift
+++ b/Sources/SoundpipeAudioKit/Generators/PhaseLockedVocoder.swift
@@ -158,6 +158,9 @@ public class PhaseLockedVocoder: Node {
                         bufferList.mBuffers.mData?.assumingMemoryBound(to: Float.self)
                     )
                     au.setWavetable(data: data, size: Int(ioNumberFrames))
+                    // Fixing a previous memory leak
+                    theData?.deallocate()
+                    theData = nil
                 } else {
                     // failure
                     theData?.deallocate()


### PR DESCRIPTION
au.setWaveTable in line 160 copies the data to the au, so we can safely free the memory of "theData"