### PR TITLE
Update SoundpipeDSPBase process in place

### DIFF
--- a/Sources/CSoundpipeAudioKit/include/SoundpipeDSPBase.h
+++ b/Sources/CSoundpipeAudioKit/include/SoundpipeDSPBase.h
@@ -11,7 +11,7 @@ protected:
     struct sp_data *sp = nullptr;
     float internalTrigger=0;
 public:
-    SoundpipeDSPBase(int inputBusCount=1, bool canProcessInPlace=true) : DSPBase(inputBusCount, canProcessInPlace) { }
+    SoundpipeDSPBase(int inputBusCount=1, bool canProcessInPlace=false) : DSPBase(inputBusCount, canProcessInPlace) { }
 
     virtual void init(int channelCount, double sampleRate) override;
     virtual void deinit() override;


### PR DESCRIPTION
This sets the value `canProcessInPlace=false` which is the same as DSPBase by default. It is needed to pass Logic's AUVal to support both mono and stereo.