### PR TITLE
Add a user-definable "grain size" to PhaseLockedVocoder

### DIFF
--- a/Sources/CSoundpipeAudioKit/include/CSoundpipeAudioKit.h
+++ b/Sources/CSoundpipeAudioKit/include/CSoundpipeAudioKit.h
@@ -13,4 +13,5 @@ void akCombFilterReverbSetLoopDuration(DSPRef dsp, float duration);
 void akConvolutionSetPartitionLength(DSPRef dsp, int length);
 void akFlatFrequencyResponseSetLoopDuration(DSPRef dsp, float duration);
 void akVariableDelaySetMaximumTime(DSPRef dsp, float maximumTime);
+void akPhaseLockedVocoderSetMincerSize(DSPRef dspRef, int size);
 CF_EXTERN_C_END

--- a/Sources/SoundpipeAudioKit/Generators/PhaseLockedVocoder.swift
+++ b/Sources/SoundpipeAudioKit/Generators/PhaseLockedVocoder.swift
@@ -4,6 +4,7 @@ import AudioKit
 import AudioKitEX
 import AVFoundation
 import CAudioKitEX
+import CSoundpipeAudioKit
 
 /// This is a phase locked vocoder. It has the ability to play back an audio
 /// file loaded into an ftable like a sampler would. Unlike a typical sampler,
@@ -25,7 +26,7 @@ public class PhaseLockedVocoder: Node {
         range: 0 ... 100_000,
         unit: .generic
     )
-
+    
     /// Position in time. When non-changing it will do a spectral freeze of a the current point in time.
     @Parameter(positionDef) public var position: AUValue
 
@@ -69,15 +70,34 @@ public class PhaseLockedVocoder: Node {
         file: AVAudioFile,
         position: AUValue = positionDef.defaultValue,
         amplitude: AUValue = amplitudeDef.defaultValue,
-        pitchRatio: AUValue = pitchRatioDef.defaultValue
+        pitchRatio: AUValue = pitchRatioDef.defaultValue,
+        grainSize: Int32 = 2048
     ) {
         setupParameters()
 
         loadFile(file)
+        
+        let safeGrainSize = roundUpToPowerOfTwo(grainSize)
+        akPhaseLockedVocoderSetMincerSize(au.dsp, safeGrainSize)
 
         self.position = position
         self.amplitude = amplitude
         self.pitchRatio = pitchRatio
+    }
+
+    /// The grain size range is 128 - 8192 and it must be a power of two. If it isn't one already, this function will round it up to the next power of two
+    /// (should we warn the user if they submit a value which is not in that range or is not a power of two?)
+    func roundUpToPowerOfTwo(_ value: Int32) -> Int32 {
+        let range: ClosedRange<Int32> = 128...8192
+        guard range.contains(value) else { return min(max(value, range.lowerBound), range.upperBound) }
+        var result = value - 1
+        result |= result >> 1
+        result |= result >> 2
+        result |= result >> 4
+        result |= result >> 8
+        result |= result >> 16
+        result += 1
+        return result
     }
     
     /// Call this function after you are done with the node, to reset the au wavetable to prevent memory leaks


### PR DESCRIPTION
The size of the mincer in the DSP can be set on init of PhaseLockedVocoder in a range of 128...8192. A smaller value makes the sound crisper when the sample position is moved. But a greater mincer size might also be desirable because the spectral freeze changes audibly.