### PR TITLE
Revert canProcessInPlace in SoundpipeDSPBase

### DIFF
--- a/Sources/CSoundpipeAudioKit/include/SoundpipeDSPBase.h
+++ b/Sources/CSoundpipeAudioKit/include/SoundpipeDSPBase.h
@@ -11,7 +11,7 @@ protected:
     struct sp_data *sp = nullptr;
     float internalTrigger=0;
 public:
-    SoundpipeDSPBase(int inputBusCount=1, bool canProcessInPlace=false) : DSPBase(inputBusCount, canProcessInPlace) { }
+    SoundpipeDSPBase(int inputBusCount=1, bool canProcessInPlace=true) : DSPBase(inputBusCount, canProcessInPlace) { }
 
     virtual void init(int channelCount, double sampleRate) override;
     virtual void deinit() override;


### PR DESCRIPTION
This reverts a change that caused a crash when bypassing certain Soundpipe nodes (like PhaseLockedVocoder). That refactor will take more looking into. Mentioned here: #46
